### PR TITLE
Create CODEOWNERS on request from team security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/CODEOWNERS                         @altinn/team-app-migration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Team security have requested that all Altinn repos should implement CODEOWNERS pointing to the owning team. https://digdir.slack.com/archives/C0796P42YD7/p1747662272552819

